### PR TITLE
Build AOT demos with taichi as subdirectory to workaround cross-platform compilation issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@
 __pycache__/
 *.pyc
 /implicit_fem/python/imgui.ini
+
+.vs
+.idea
+tmp
+imgui.ini
+*.log

--- a/implicit_fem/README.md
+++ b/implicit_fem/README.md
@@ -16,21 +16,19 @@ android/  # android demo
 ```
 
 ## Desktop Demo
+
 ```
 export TAICHI_REPO_DIR=/path/github/taichi/
 cd desktop
 mkdir build
-cd build && cmake .. && make
+cd build && cmake .. && cmake --build . --config=Release
 ```
 
-Taichi built with
-
-```
-python setup.py clean && TAICHI_CMAKE_ARGS="-DTI_WITH_VULKAN:BOOL=ON -DTI_WITH_CUDA:BOOL=OFF -DTI_WITH_OPENGL:BOOL=OFF -DTI_WITH_LLVM:BOOL=OFF -DTI_EXPORT_CORE:BOOL=ON" python3 setup.py build_ext
-```
+Or you can open `desktop` as folder in Visual Studio 2019+ for better debugging experience.
 
 ## Android Demo
 If you are building Taichi with custom changes, make sure to copy the prebuilt `libtaichi_export_core.so` to: `app/src/main/jniLibs/arm64-v8a/`
+
 ```
 export TAICHI_REPO_DIR=/path/github/taichi/
 export ANDROID_SDK_ROOT=/path/to/Andriod/Sdk
@@ -40,11 +38,7 @@ ln -s ${TAICHI_REPO_DIR}/_skbuild/linux-x86_64-3.8/cmake-build/libtaichi_export_
 adb install ./app/build/outputs/apk/debug/app-debug.apk
 ```
 
-Taichi built with
-```
-export ANDROID_NDK_ROOT="<path_to_android_ndk>"  # e.g. ~/Android/Sdk/ndk/22.1.7171670/
-python setup.py clean && TAICHI_CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK_ROOT}/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=29 -DANDROID_ABI=arm64-v8a" python3 setup.py build_ext
-```
+Or you can open `android` in Android Studio Bumblebee Canary 13+ (2021.1.1.13+) for better debugging experience. Earlier releases have broken support for CMake object library and please refer to [this Android Studio issue](https://issuetracker.google.com/issues/198756433) for more information.
 
 ## Troubleshooting
 

--- a/implicit_fem/android/.gitignore
+++ b/implicit_fem/android/.gitignore
@@ -1,0 +1,2 @@
+/app/src/main/cpp/taichi/common/version.h
+/app/src/main/cpp/taichi/common/commit_hash.h

--- a/implicit_fem/android/app/build.gradle
+++ b/implicit_fem/android/app/build.gradle
@@ -18,7 +18,7 @@ def getAndroidSdkDirectory() {
 
 android {
     compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    buildToolsVersion '31.0.0'
     ndkVersion '22.1.7171670'
 
     defaultConfig {

--- a/implicit_fem/android/app/src/main/cpp/CMakeLists.txt
+++ b/implicit_fem/android/app/src/main/cpp/CMakeLists.txt
@@ -1,5 +1,15 @@
 cmake_minimum_required(VERSION 3.8)
 
+project(implicit_fem)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+find_library(log-lib log)
+find_library(android-lib android)
+find_package(Vulkan)
+
+
 if (NOT DEFINED ENV{TAICHI_REPO_DIR})
     message(FATAL_ERROR "TAICHI_REPO_DIR not set")
 endif()
@@ -9,11 +19,6 @@ set(TAICHI_REPO_DIR $ENV{TAICHI_REPO_DIR})
 # build main native library
 set(JNILIBS_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../jniLibs/${ANDROID_ABI}/)
 
-if (EXISTS "${JNILIBS_PATH}/libtaichi_export_core.so")
-  link_directories(${JNILIBS_PATH})
-else()
-  message(FATAL_ERROR "Please copy libtaichi_export_core.so to ${JNILIBS_PATH}")
-endif()
 
 # build native_app_glue as a static lib
 set(${CMAKE_C_FLAGS}, "${CMAKE_C_FLAGS}")
@@ -27,7 +32,17 @@ set(CMAKE_SHARED_LINKER_FLAGS
 
 add_library(taichi-implicit-fem SHARED implicit_fem.cpp)
 
-target_compile_options(taichi-implicit-fem PUBLIC -Wall -Wextra -std=c++17 -DTI_WITH_VULKAN -DTI_INCLUDED)
+
+set(TI_WITH_VULKAN ON)
+set(TI_WITH_OPENGL OFF)
+set(TI_WITH_LLVM OFF)
+set(TI_WITH_CC OFF)
+set(TI_WITH_PYTHON OFF)
+set(TI_EXPORT_CORE ON)
+add_subdirectory(${TAICHI_REPO_DIR} taichi)
+
+
+target_compile_options(taichi-implicit-fem PUBLIC -Wall -Wextra -DTI_WITH_VULKAN -DTI_INCLUDED)
 
 target_include_directories(taichi-implicit-fem PUBLIC ${TAICHI_REPO_DIR}/)
 target_include_directories(taichi-implicit-fem PUBLIC ${TAICHI_REPO_DIR}/taichi/backends/vulkan)
@@ -43,4 +58,4 @@ target_include_directories(taichi-implicit-fem PUBLIC ${TAICHI_REPO_DIR}/externa
 target_include_directories(taichi-implicit-fem PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../include/)
 target_include_directories(taichi-implicit-fem PUBLIC ${ANDROID_NDK}/sources/android/native_app_glue)
 
-target_link_libraries(taichi-implicit-fem android log m vulkan taichi_export_core native_app_glue)
+target_link_libraries(taichi-implicit-fem android log m Vulkan native_app_glue taichi_isolated_core)

--- a/implicit_fem/android/build.gradle
+++ b/implicit_fem/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:7.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/implicit_fem/android/gradle/wrapper/gradle-wrapper.properties
+++ b/implicit_fem/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 27 14:52:51 PDT 2021
+#Wed May 18 13:38:09 CST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/implicit_fem/desktop/.gitignore
+++ b/implicit_fem/desktop/.gitignore
@@ -2,3 +2,6 @@
 taichi-vk-launcher
 *.spv
 build
+
+/taichi/common/version.h
+/taichi/common/commit_hash.h

--- a/implicit_fem/desktop/CMakeLists.txt
+++ b/implicit_fem/desktop/CMakeLists.txt
@@ -1,19 +1,41 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.15)
 
-project(implicit_fem)
+project(implicit_fem LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+if (NOT CMAKE_BUILD_TYPE)
+    message(STATUS "No build type selected, default to Release")
+    set(CMAKE_BUILD_TYPE "Release" CACHE PATH "Build Type" FORCE)
+endif()
+
+
 add_executable(implicit_fem implicit_fem.cpp)
 
-target_compile_options(implicit_fem PUBLIC -Wall -Wextra -DTI_WITH_VULKAN -DTI_INCLUDED -DTI_ARCH_x64)
 
 if (NOT DEFINED ENV{TAICHI_REPO_DIR})
     message(FATAL_ERROR "TAICHI_REPO_DIR not set")
+else()
+    set(TAICHI_REPO_DIR $ENV{TAICHI_REPO_DIR})
 endif()
 
-set(TAICHI_REPO_DIR $ENV{TAICHI_REPO_DIR})
+
+add_definitions(-D_GLFW_BUILD_DLL -DTI_INCLUDED)
+if (MSVC)
+    target_compile_options(implicit_fem PUBLIC "/Zc:__cplusplus")
+    set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
+endif()
+
+
+set(TI_WITH_VULKAN ON)
+set(TI_WITH_OPENGL OFF)
+set(TI_WITH_LLVM OFF)
+set(TI_WITH_CC OFF)
+set(TI_WITH_PYTHON OFF)
+set(TI_EXPORT_CORE ON)
+add_subdirectory(${TAICHI_REPO_DIR} taichi)
+
 
 target_include_directories(implicit_fem PUBLIC ${TAICHI_REPO_DIR}/)
 target_include_directories(implicit_fem PUBLIC ${TAICHI_REPO_DIR}/taichi/backends/vulkan)
@@ -31,5 +53,4 @@ target_include_directories(implicit_fem PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../in
 
 target_link_directories(implicit_fem PUBLIC ${TAICHI_REPO_DIR}/build)
 
-target_link_libraries(implicit_fem PUBLIC taichi_export_core)
-
+target_link_libraries(implicit_fem PUBLIC taichi_isolated_core glfw)

--- a/implicit_fem/desktop/implicit_fem.cpp
+++ b/implicit_fem/desktop/implicit_fem.cpp
@@ -1,6 +1,5 @@
 #include <inttypes.h>
 #include <signal.h>
-#include <unistd.h>
 
 #include <iostream>
 


### PR DESCRIPTION
- Fixed linking issue on Windows;
- Fixed crashes when compiled with incompatible versions of clang.