### PR TITLE
Simplify the usage of taichi_export_core in Cmake for Implicit_fem

### DIFF
--- a/implicit_fem/README.md
+++ b/implicit_fem/README.md
@@ -16,17 +16,18 @@ android/  # android demo
 ```
 
 ## Desktop Demo
-```
-export TAICHI_REPO_DIR=/path/github/taichi/
-cd desktop
-mkdir build
-cd build && cmake .. && make
-```
-
 Taichi built with
 
 ```
 python setup.py clean && TAICHI_CMAKE_ARGS="-DTI_WITH_VULKAN:BOOL=ON -DTI_WITH_CUDA:BOOL=OFF -DTI_WITH_OPENGL:BOOL=OFF -DTI_WITH_LLVM:BOOL=OFF -DTI_EXPORT_CORE:BOOL=ON" python3 setup.py build_ext
+```
+Upon successful completion, the build artifacts should be located at `_skbuild/*/cmake-install` within the taichi directory. Then, provide this path to CMake as 
+
+```
+cd desktop
+mkdir build && cd build
+cmake -DCMAKE_PREFIX_PATH=/path_github_taichi/_skbuild/your_system_version/cmake-install ..
+make
 ```
 
 ## Android Demo

--- a/implicit_fem/desktop/CMakeLists.txt
+++ b/implicit_fem/desktop/CMakeLists.txt
@@ -9,27 +9,8 @@ add_executable(implicit_fem implicit_fem.cpp)
 
 target_compile_options(implicit_fem PUBLIC -Wall -Wextra -DTI_WITH_VULKAN -DTI_INCLUDED -DTI_ARCH_x64)
 
-if (NOT DEFINED ENV{TAICHI_REPO_DIR})
-    message(FATAL_ERROR "TAICHI_REPO_DIR not set")
-endif()
-
-set(TAICHI_REPO_DIR $ENV{TAICHI_REPO_DIR})
-
-target_include_directories(implicit_fem PUBLIC ${TAICHI_REPO_DIR}/)
-target_include_directories(implicit_fem PUBLIC ${TAICHI_REPO_DIR}/taichi/backends/vulkan)
-target_include_directories(implicit_fem PUBLIC ${TAICHI_REPO_DIR}/external/Vulkan-Headers/include/)
-target_include_directories(implicit_fem PUBLIC ${TAICHI_REPO_DIR}/external/SPIRV-Tools/include/)
-target_include_directories(implicit_fem PUBLIC ${TAICHI_REPO_DIR}/external/volk/)
-target_include_directories(implicit_fem PUBLIC ${TAICHI_REPO_DIR}/external/glm/)
-target_include_directories(implicit_fem PUBLIC ${TAICHI_REPO_DIR}/external/imgui/)
-target_include_directories(implicit_fem PUBLIC ${TAICHI_REPO_DIR}/external/glfw/include)
-target_include_directories(implicit_fem PUBLIC ${TAICHI_REPO_DIR}/external/imgui/backends)
-target_include_directories(implicit_fem PUBLIC ${TAICHI_REPO_DIR}/external/eigen/)
-target_include_directories(implicit_fem PUBLIC ${TAICHI_REPO_DIR}/external/spdlog/include/)
-target_include_directories(implicit_fem PUBLIC ${TAICHI_REPO_DIR}/external/VulkanMemoryAllocator/include/)
 target_include_directories(implicit_fem PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include/)
 
-target_link_directories(implicit_fem PUBLIC ${TAICHI_REPO_DIR}/build)
+find_package(taichi_export_core REQUIRED CONFIG)
 
-target_link_libraries(implicit_fem PUBLIC taichi_export_core)
-
+target_link_libraries(implicit_fem PUBLIC taichi_export_core::taichi_export_core)

--- a/implicit_fem/include/fem_app.h
+++ b/implicit_fem/include/fem_app.h
@@ -3,7 +3,7 @@
 #include <taichi/runtime/gfx/aot_module_loader_impl.h>
 #include <taichi/backends/vulkan/vulkan_common.h>
 #include <taichi/backends/vulkan/vulkan_loader.h>
-#include <taichi/backends/vulkan/vulkan_program.h>
+#include <taichi/runtime/program_impls/vulkan/vulkan_program.h>
 #include <taichi/gui/gui.h>
 #include <taichi/inc/constants.h>
 #include <taichi/ui/backends/vulkan/renderer.h>


### PR DESCRIPTION
Merge this after https://github.com/taichi-dev/taichi/pull/5162 is merged.

Instead of manually linking the `.so` library and providing include paths, [#5162](https://github.com/taichi-dev/taichi/pull/5162) simplifies the cmake usage for Taichi library clients. Now, Taichi can generate the cmake configuration files for the `taichi_export_core` library. This allows linking the library in just two cmake instructions:

```
find_package(taichi_export_core REQUIRED CONFIG)
target_link_libraries(implicit_fem PUBLIC taichi_export_core::taichi_export_core)
```  
This PR updates the cmake file for the implicit_fem example. 

 