### PR TITLE
Fixed AOT demo renderer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ find_package(Vulkan REQUIRED)
 add_subdirectory(external/glfw)
 add_subdirectory(external/VulkanMemoryAllocator)
 add_subdirectory(external/glslang)
+set(BUILD_TESTING OFF)
+set(BUILD_STATIC_LIBS ON)
 add_subdirectory(external/glm)
 add_library(GraphiT OBJECT
     "${CMAKE_CURRENT_SOURCE_DIR}/external/graphi-t/include/gft/args.hpp"


### PR DESCRIPTION
- Fixed blitting image before synchronization in the headless entry point;
- Fixed validation errors because of unenabled extension features.