### PR TITLE
[debug] Enable backward-cpp for better stack trace

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "external/glm"]
 	path = external/glm
 	url = https://github.com/g-truc/glm
+[submodule "external/backward-cpp"]
+	path = external/backward-cpp
+	url = https://github.com:bombela/backward-cpp

--- a/2_mpm88/app.cpp
+++ b/2_mpm88/app.cpp
@@ -6,6 +6,15 @@
 
 using namespace ti::aot_demo;
 
+namespace {
+void ti_check_error(const std::string& msg) {
+  TiError error = ti_get_last_error(0, nullptr);
+  if (error < TI_ERROR_SUCCESS) {
+    throw std::runtime_error(msg);
+  }
+}
+}
+
 struct App2_mpm88 : public App {
   static const uint32_t NPARTICLE = 8192 * 2;
   static const uint32_t GRID_SIZE = 128;
@@ -35,8 +44,11 @@ struct App2_mpm88 : public App {
     GraphicsRuntime& runtime = F.runtime();
 
     module_ = runtime.load_aot_module("2_mpm88/assets/mpm88");
+    ti_check_error("load_aot_module failed");
+
     g_init_ = module_.get_compute_graph("init");
     g_update_ = module_.get_compute_graph("update");
+    ti_check_error("get_compute_graph failed");
 
     x_ = runtime.allocate_vertex_buffer(NPARTICLE, 2);
     v_ = runtime.allocate_ndarray<float>({NPARTICLE}, {2});
@@ -45,6 +57,7 @@ struct App2_mpm88 : public App {
     J_ = runtime.allocate_ndarray<float>({NPARTICLE}, {});
     grid_v_ = runtime.allocate_ndarray<float>({GRID_SIZE, GRID_SIZE}, {2});
     grid_m_ = runtime.allocate_ndarray<float>({GRID_SIZE, GRID_SIZE}, {});
+    ti_check_error("allocate_ndarray failed");
 
     draw_points = runtime.draw_points(x_)
       .point_size(3.0f)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,9 +113,9 @@ if (TI_WITH_CPU)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_CPU")
     list(APPEND TAICHI_AOT_DEMO_LIST "1_hello_world_with_cpu_interop")
     list(APPEND TaichiAotDemoFramework_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/framework/src/taichi/aot_demo/interop/cross_device_copy.cpp")
-    
+
 endif()
-    
+
 if (TI_WITH_CUDA)
     find_package(CUDAToolkit REQUIRED)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_CUDA -DTI_NO_CUDA_INCLUDES=ON")
@@ -126,6 +126,7 @@ if (TI_WITH_CUDA)
 endif()
 list(REMOVE_DUPLICATES TaichiAotDemoFramework_SOURCES)
 
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/external/backward-cpp")
 
 foreach(TAICHI_AOT_DEMO_DIR ${TAICHI_AOT_DEMO_LIST})
     add_subdirectory(${TAICHI_AOT_DEMO_DIR} ${TAICHI_AOT_DEMO_CURRENT_TARGET})
@@ -143,7 +144,7 @@ foreach(TAICHI_AOT_ENTRY_POINT ${TAICHI_AOT_ENTRY_POINT_LIST})
 
         add_executable(${TAICHI_AOT_DEMO_CURRENT_TARGET}
             "${CMAKE_CURRENT_SOURCE_DIR}/framework/src/taichi/aot_demo/entry_points/${TAICHI_AOT_ENTRY_POINT}.cpp"
-            ${TaichiAotDemoFramework_SOURCES})
+            ${TaichiAotDemoFramework_SOURCES} ${BACKWARD_ENABLE})
         set_target_properties(${TAICHI_AOT_DEMO_CURRENT_TARGET} PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${TAICHI_AOT_ENTRY_POINT})
         target_link_libraries(${TAICHI_AOT_DEMO_CURRENT_TARGET} PUBLIC
@@ -151,6 +152,7 @@ foreach(TAICHI_AOT_ENTRY_POINT ${TAICHI_AOT_ENTRY_POINT_LIST})
             ${TaichiAotDemoFramework_LINK_LIBRARIES})
         target_include_directories(${TAICHI_AOT_DEMO_CURRENT_TARGET} PUBLIC
             ${TaichiAotDemoFramework_INCLUDE_DIRECTORIES})
+        add_backward(${TAICHI_AOT_DEMO_CURRENT_TARGET})
 
         # Some settings for specific entry points.
         if(${TAICHI_AOT_ENTRY_POINT} STREQUAL "glfw")


### PR DESCRIPTION
To enable you'll need `cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo`.

Added a few `ti_check_error`  in mpm88 demo, will spread it across different demos if this one passes CI (in taichi master)

Example output:

![Screenshot from 2022-11-02 09-43-28](https://user-images.githubusercontent.com/5248122/199379150-704f2d2c-9715-406a-8e53-c0c7c067ac5e.png)
