### PR TITLE
[debug] Enable backward-cpp in tutorial demos

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "external/glm"]
 	path = external/glm
 	url = https://github.com/g-truc/glm
+[submodule "external/backward-cpp"]
+	path = external/backward-cpp
+	url = git@github.com:bombela/backward-cpp.git

--- a/0_tutorial_cgraph/CMakeLists.txt
+++ b/0_tutorial_cgraph/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TAICHI_TUTORIAL_DEMO_NAME "E0_tutorial_cgraph")
 message("-- Building ${TAICHI_TUTORIAL_DEMO_NAME}")
-add_executable(${TAICHI_TUTORIAL_DEMO_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/app.cpp)
+add_executable(${TAICHI_TUTORIAL_DEMO_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/app.cpp ${BACKWARD_ENABLE})
 target_include_directories(${TAICHI_TUTORIAL_DEMO_NAME} PUBLIC ${TAICHI_C_API_INSTALL_DIR}/include)
 target_link_libraries(${TAICHI_TUTORIAL_DEMO_NAME} ${taichi_c_api})
 set_target_properties(${TAICHI_TUTORIAL_DEMO_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../tutorial)
+add_backward(${TAICHI_TUTORIAL_DEMO_NAME})

--- a/0_tutorial_cgraph/app.cpp
+++ b/0_tutorial_cgraph/app.cpp
@@ -3,6 +3,15 @@
 #include <numeric>
 #include <taichi/cpp/taichi.hpp>
 
+namespace {
+void ti_check_error(const std::string& msg) {
+  TiError error = ti_get_last_error(0, nullptr);
+  if (error < TI_ERROR_SUCCESS) {
+    throw std::runtime_error(msg);
+  }
+}
+}
+
 struct App0_tutorial {
   // This is different from what used in python script since compiled shaders are compatible with dynamic ndarray shape
   static const uint32_t NPARTICLE = 8192 * 2;
@@ -16,8 +25,11 @@ struct App0_tutorial {
   App0_tutorial() {
     runtime_ = ti::Runtime(TI_ARCH_VULKAN);
     module_ = runtime_.load_aot_module("0_tutorial_cgraph/assets/tutorial");
+    ti_check_error("load_aot_module failed");
     g_demo_ = module_.get_compute_graph("demo_graph");
+    ti_check_error("get_compute_graph failed");
     x_ = runtime_.allocate_ndarray<float>({NPARTICLE}, {}, /*host_accessible=*/true);
+    ti_check_error("allocate_ndarray failed");
     std::cout << "Initialized!" << std::endl;
   }
 
@@ -29,6 +41,7 @@ struct App0_tutorial {
 
     g_demo_.launch();
     runtime_.wait();
+    ti_check_error("cgraph launch failed");
 
     std::vector<float> dst(NPARTICLE);
     x_.read(dst);

--- a/0_tutorial_kernel/CMakeLists.txt
+++ b/0_tutorial_kernel/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TAICHI_TUTORIAL_DEMO_NAME "E0_tutorial_kernel")
 message("-- Building ${TAICHI_TUTORIAL_DEMO_NAME}")
-add_executable(${TAICHI_TUTORIAL_DEMO_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/app.cpp)
+add_executable(${TAICHI_TUTORIAL_DEMO_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/app.cpp ${BACKWARD_ENABLE})
 target_include_directories(${TAICHI_TUTORIAL_DEMO_NAME} PUBLIC ${TAICHI_C_API_INSTALL_DIR}/include)
 target_link_libraries(${TAICHI_TUTORIAL_DEMO_NAME} ${taichi_c_api})
 set_target_properties(${TAICHI_TUTORIAL_DEMO_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../tutorial)
+add_backward(${TAICHI_TUTORIAL_DEMO_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.13)
 project(TaichiAotDemo LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 14)
+# Change this to release in real application.
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
 
 option(TI_WITH_VULKAN "Compile with Vulkan backend" ON)
 option(TI_WITH_CPU "Compile with CPU backend" OFF)
@@ -68,7 +70,8 @@ add_library(GraphiT OBJECT
     "${CMAKE_CURRENT_SOURCE_DIR}/external/graphi-t/src/gft/args.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/external/graphi-t/src/gft/util.cpp")
 target_include_directories(GraphiT PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/external/graphi-t/include")
-
+# Backward-cpp
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/external/backward-cpp")
 
 # Declare framework target.
 list(APPEND TaichiAotDemoFramework_SOURCES
@@ -246,7 +249,7 @@ foreach(PYTHON_SCRIPT ${TAICHI_AOT_PYTHON_LIST})
     string(REPLACE " " ";" PYTHON_SCRIPT ${PYTHON_SCRIPT})
     list(GET PYTHON_SCRIPT 0 PYTHON_FILE)
     list(GET PYTHON_SCRIPT 1 ARGS)
-    execute_process(COMMAND ${PYTHON_EXECUTABLE} ${PYTHON_FILE} ${ARGS})
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} ${PYTHON_FILE} ${ARGS} --arch vulkan)
 endforeach()
 
 # 0_tutorial is intended to be minimal code for demonstration so it's independent of framework.
@@ -255,3 +258,4 @@ add_subdirectory("0_tutorial_kernel")
 
 execute_process(COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/0_tutorial_cgraph/assets/tutorial.py" --arch vulkan --aot)
 execute_process(COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/0_tutorial_kernel/assets/tutorial.py" --arch vulkan --aot)
+


### PR DESCRIPTION
Supersedes #52 to work as an demo of using backward-cpp in the application. Switched to using tutorial demos for this since it's easier to mention in tutorial content. 
![Screenshot from 2022-11-11 09-06-28](https://user-images.githubusercontent.com/5248122/201238843-2c334f95-367d-49cc-81a2-65c3e5397eff.png)
