### PR TITLE
[debug] Enable backward-cpp in tutorial demos

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "external/glm"]
 	path = external/glm
 	url = https://github.com/g-truc/glm
+[submodule "external/backward-cpp"]
+	path = external/backward-cpp
+	url = https://github.com/bombela/backward-cpp

--- a/0_tutorial_cgraph/CMakeLists.txt
+++ b/0_tutorial_cgraph/CMakeLists.txt
@@ -1,6 +1,20 @@
 set(TAICHI_TUTORIAL_DEMO_NAME "E0_tutorial_cgraph")
 message("-- Building ${TAICHI_TUTORIAL_DEMO_NAME}")
-add_executable(${TAICHI_TUTORIAL_DEMO_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/app.cpp)
+
+list(APPEND TAICHI_TUTORIAL_DEMO_SRC
+  ${CMAKE_CURRENT_SOURCE_DIR}/app.cpp
+)
+if (NOT ANDROID)
+  list(APPEND TAICHI_TUTORIAL_DEMO_SRC
+    ${BACKWARD_ENABLE}
+  )
+endif()
+
+add_executable(${TAICHI_TUTORIAL_DEMO_NAME} ${TAICHI_TUTORIAL_DEMO_SRC})
 target_include_directories(${TAICHI_TUTORIAL_DEMO_NAME} PUBLIC ${TAICHI_C_API_INSTALL_DIR}/include)
 target_link_libraries(${TAICHI_TUTORIAL_DEMO_NAME} ${taichi_c_api})
 set_target_properties(${TAICHI_TUTORIAL_DEMO_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../tutorial)
+
+if (NOT ANDROID)
+  add_backward(${TAICHI_TUTORIAL_DEMO_NAME})
+endif()

--- a/0_tutorial_cgraph/app.cpp
+++ b/0_tutorial_cgraph/app.cpp
@@ -3,6 +3,15 @@
 #include <numeric>
 #include <taichi/cpp/taichi.hpp>
 
+namespace {
+void check_taichi_error(const std::string& msg) {
+  TiError error = ti_get_last_error(0, nullptr);
+  if (error < TI_ERROR_SUCCESS) {
+    throw std::runtime_error(msg);
+  }
+}
+}
+
 struct App0_tutorial {
   // This is different from what used in python script since compiled shaders are compatible with dynamic ndarray shape
   static const uint32_t NPARTICLE = 8192 * 2;
@@ -16,8 +25,11 @@ struct App0_tutorial {
   App0_tutorial() {
     runtime_ = ti::Runtime(TI_ARCH_VULKAN);
     module_ = runtime_.load_aot_module("0_tutorial_cgraph/assets/tutorial");
+    check_taichi_error("load_aot_module failed");
     g_demo_ = module_.get_compute_graph("demo_graph");
+    check_taichi_error("get_compute_graph failed");
     x_ = runtime_.allocate_ndarray<float>({NPARTICLE}, {}, /*host_accessible=*/true);
+    check_taichi_error("allocate_ndarray failed");
     std::cout << "Initialized!" << std::endl;
   }
 
@@ -29,6 +41,7 @@ struct App0_tutorial {
 
     g_demo_.launch();
     runtime_.wait();
+    check_taichi_error("cgraph launch failed");
 
     std::vector<float> dst(NPARTICLE);
     x_.read(dst);

--- a/0_tutorial_kernel/CMakeLists.txt
+++ b/0_tutorial_kernel/CMakeLists.txt
@@ -1,6 +1,20 @@
 set(TAICHI_TUTORIAL_DEMO_NAME "E0_tutorial_kernel")
 message("-- Building ${TAICHI_TUTORIAL_DEMO_NAME}")
-add_executable(${TAICHI_TUTORIAL_DEMO_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/app.cpp)
+
+list(APPEND TAICHI_TUTORIAL_DEMO_SRC
+  ${CMAKE_CURRENT_SOURCE_DIR}/app.cpp
+)
+if (NOT ANDROID)
+  list(APPEND TAICHI_TUTORIAL_DEMO_SRC
+    ${BACKWARD_ENABLE}
+  )
+endif()
+
+add_executable(${TAICHI_TUTORIAL_DEMO_NAME} ${TAICHI_TUTORIAL_DEMO_SRC})
 target_include_directories(${TAICHI_TUTORIAL_DEMO_NAME} PUBLIC ${TAICHI_C_API_INSTALL_DIR}/include)
 target_link_libraries(${TAICHI_TUTORIAL_DEMO_NAME} ${taichi_c_api})
 set_target_properties(${TAICHI_TUTORIAL_DEMO_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../tutorial)
+
+if (NOT ANDROID)
+  add_backward(${TAICHI_TUTORIAL_DEMO_NAME})
+endif()

--- a/0_tutorial_kernel/app.cpp
+++ b/0_tutorial_kernel/app.cpp
@@ -3,6 +3,15 @@
 #include <numeric>
 #include <taichi/cpp/taichi.hpp>
 
+namespace {
+void check_taichi_error(const std::string& msg) {
+  TiError error = ti_get_last_error(0, nullptr);
+  if (error < TI_ERROR_SUCCESS) {
+    throw std::runtime_error(msg);
+  }
+}
+}
+
 struct App0_tutorial {
   // This is different from what used in python script since compiled shaders are compatible with dynamic ndarray shape
   static const uint32_t NPARTICLE = 8192 * 2;
@@ -17,9 +26,12 @@ struct App0_tutorial {
   App0_tutorial() {
     runtime_ = ti::Runtime(TI_ARCH_VULKAN);
     module_ = runtime_.load_aot_module("0_tutorial_kernel/assets/tutorial");
+    check_taichi_error("load_aot_module failed");
     k_init_ = module_.get_kernel("init");
     k_add_base_ = module_.get_kernel("add_base");
+    check_taichi_error("get_kernel failed");
     x_ = runtime_.allocate_ndarray<float>({NPARTICLE}, {}, /*host_accessible=*/true);
+    check_taichi_error("allocate_ndarray failed");
     std::cout << "Initialized!" << std::endl;
   }
 
@@ -34,6 +46,7 @@ struct App0_tutorial {
       k_add_base_.launch();
     }
     runtime_.wait();
+    check_taichi_error("kernel launch failed");
 
     std::vector<float> dst(NPARTICLE);
     x_.read(dst);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.13)
 project(TaichiAotDemo LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 14)
+# Change this to release in real application.
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
 
 option(TI_WITH_VULKAN "Compile with Vulkan backend" ON)
 option(TI_WITH_CPU "Compile with CPU backend" OFF)
@@ -69,6 +71,10 @@ add_library(GraphiT OBJECT
     "${CMAKE_CURRENT_SOURCE_DIR}/external/graphi-t/src/gft/util.cpp")
 target_include_directories(GraphiT PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/external/graphi-t/include")
 
+if (NOT ANDROID)
+  # Backward-cpp
+  add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/external/backward-cpp")
+endif()
 
 # Declare framework target.
 list(APPEND TaichiAotDemoFramework_SOURCES
@@ -255,3 +261,4 @@ add_subdirectory("0_tutorial_kernel")
 
 execute_process(COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/0_tutorial_cgraph/assets/tutorial.py" --arch vulkan --aot)
 execute_process(COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/0_tutorial_kernel/assets/tutorial.py" --arch vulkan --aot)
+


### PR DESCRIPTION
CI passed at https://github.com/taichi-dev/taichi/actions/runs/3441841847/jobs/5742454417. 
Supersedes https://github.com/taichi-dev/taichi-aot-demo/pull/52 to work as a demo of using backward-cpp in the application. Switched to using tutorial demos for this since it's easier to mention in tutorial content.
![Screenshot from 2022-11-11 09-06-28](https://user-images.githubusercontent.com/5248122/201243798-6d6d9330-ed02-4b11-aa97-a622e76ccac6.png)
